### PR TITLE
Replace id_token by access_token in TokensBag

### DIFF
--- a/src/Security/Dto/TokensBag.php
+++ b/src/Security/Dto/TokensBag.php
@@ -5,14 +5,14 @@ namespace App\Security\Dto;
 final class TokensBag
 {
     public function __construct(
-        private string $jwt,
+        private string $accessToken,
         private string $refreshToken,
-        private ?int $jwtExpires = null,
+        private ?int   $jwtExpires = null,
     ) {}
 
-    public function getJwt(): string
+    public function getAccessToken(): string
     {
-        return $this->jwt;
+        return $this->accessToken;
     }
 
     public function getJwtExpires(): int
@@ -31,7 +31,7 @@ final class TokensBag
 
     public function withExpiration(int $jwtExpires): static
     {
-        $static = new static($this->jwt, $this->refreshToken);
+        $static = new static($this->accessToken, $this->refreshToken);
         $static->jwtExpires = $jwtExpires;
 
         return $static;

--- a/src/Security/Listener/JwtRefreshListener.php
+++ b/src/Security/Listener/JwtRefreshListener.php
@@ -82,7 +82,11 @@ final class JwtRefreshListener implements EventSubscriberInterface
         }
         $request->attributes->remove('_app_jwt_expires');
 
-        $token->setAttribute(TokensBag::class, new TokensBag($jwtToken, $refreshToken, $jwtExpires));
+        $token->setAttribute(TokensBag::class, new TokensBag(
+            $responseData['access_token'] ?? null,
+            $refreshToken,
+            $jwtExpires,
+        ));
 
         $token->setUser($user);
     }

--- a/src/Security/Listener/LogoutListener.php
+++ b/src/Security/Listener/LogoutListener.php
@@ -31,7 +31,7 @@ final class LogoutListener implements EventSubscriberInterface
             throw new \LogicException(sprintf('%s token attribute is empty', TokensBag::class));
         }
 
-        $this->openIdClient->logout($tokens->getJwt(), $tokens->getRefreshToken());
+        $this->openIdClient->logout($tokens->getAccessToken(), $tokens->getRefreshToken());
     }
 
     public function redirectToTargetPath(LogoutEvent $event): void

--- a/src/Security/OpenIdAuthenticator.php
+++ b/src/Security/OpenIdAuthenticator.php
@@ -85,7 +85,7 @@ class OpenIdAuthenticator extends AbstractAuthenticator implements Authenticatio
 
         $passport = new SelfValidatingPassport($userBadge, [new PreAuthenticatedUserBadge()]);
 
-        $passport->setAttribute(TokensBag::class, new TokensBag($jwtToken, $refreshToken));
+        $passport->setAttribute(TokensBag::class, new TokensBag($responseData['access_token'] ?? null, $refreshToken));
 
         return $passport;
     }


### PR DESCRIPTION
Since id_token is only useful for user information.
What is useful for application after authentication is access_token to access resources.